### PR TITLE
Runtime Launcher (Automatic)

### DIFF
--- a/Start Gradio.cmd
+++ b/Start Gradio.cmd
@@ -1,0 +1,7 @@
+@echo off
+IF NOT EXIST CONDA umamba create -r conda -f environment.yaml -y
+call conda\condabin\activate.bat ldm
+cls
+
+:PROMPT
+python scripts/txt2img_gradio.py

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,6 +24,7 @@ dependencies:
     - transformers==4.19.2
     - torchmetrics==0.6.0
     - kornia==0.6
+    - gradio==3.1.6
     - -e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers
     - -e git+https://github.com/openai/CLIP.git@main#egg=clip
     - -e .


### PR DESCRIPTION
With Start Gradio people no longer have to worry about dependencies, umamba is bundled because windows downloads are unreliable. Using umamba it will automatically download everything it needs to a conda folder. Once done it will launch Gradio.