### PR TITLE
Add resize argument, various fixes

### DIFF
--- a/diffusers_trainer.py
+++ b/diffusers_trainer.py
@@ -401,7 +401,7 @@ class AspectDataset(torch.utils.data.Dataset):
                 (item[1], item[2]),
                 bleed=0.0,
                 centering=(0.5, 0.5),
-                method=Image.Resampling(Image.LANCZOS)
+                method=Image.Resampling.LANCZOS
             )
 
         return_dict['pixel_values'] = self.transforms(image_file)
@@ -548,7 +548,7 @@ def main():
 
     if args.resume:
         args.model = args.resume
-
+    
     tokenizer = CLIPTokenizer.from_pretrained(args.model, subfolder='tokenizer', use_auth_token=args.hf_token)
     text_encoder = CLIPTextModel.from_pretrained(args.model, subfolder='text_encoder', use_auth_token=args.hf_token)
     vae = AutoencoderKL.from_pretrained(args.model, subfolder='vae', use_auth_token=args.hf_token)

--- a/diffusers_trainer.py
+++ b/diffusers_trainer.py
@@ -401,7 +401,7 @@ class AspectDataset(torch.utils.data.Dataset):
                 (item[1], item[2]),
                 bleed=0.0,
                 centering=(0.5, 0.5),
-                method=Image.Resampling.LANCZOS
+                method=Image.Resampling(Image.LANCZOS)
             )
 
         return_dict['pixel_values'] = self.transforms(image_file)
@@ -548,7 +548,7 @@ def main():
 
     if args.resume:
         args.model = args.resume
-    
+
     tokenizer = CLIPTokenizer.from_pretrained(args.model, subfolder='tokenizer', use_auth_token=args.hf_token)
     text_encoder = CLIPTextModel.from_pretrained(args.model, subfolder='text_encoder', use_auth_token=args.hf_token)
     vae = AutoencoderKL.from_pretrained(args.model, subfolder='vae', use_auth_token=args.hf_token)

--- a/diffusers_trainer.py
+++ b/diffusers_trainer.py
@@ -37,8 +37,7 @@ from diffusers import AutoencoderKL, UNet2DConditionModel, DDPMScheduler, PNDMSc
 from diffusers.pipelines.stable_diffusion import StableDiffusionSafetyChecker
 from diffusers.optimization import get_scheduler
 from transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer
-from PIL import Image
-from PIL import ImageOps
+from PIL import Image, ImageOps
 
 from typing import Dict, List, Generator, Tuple
 from scipy.interpolate import interp1d


### PR DESCRIPTION
### **Features:**
- Implement automagic and optional `--resize` argument (boolean) to allow people to use not previously-prepared datasets more easily and perform the associated scaling and cropping as necessary to match the best-fitting bucket. Defaults to `False`.

### **Fixes:**
- Windows users require explicit UTF-8 declaration for file read, in particular for e6 captions.
- Convert to RGB 3-channel, anything fed into `collate_fn` that hasn't been normalized in this way will cause a `torch.Size` discrepancy. E.g: `torch.Size([3, 512, 512])`, `torch.Size([4, 512, 512])`
- Make hinted type returns **a little** more accurate, and fix relevant documentation.
- Revert to Tuple[int, int, int] (idx, w, h) as implemented in @hasuwoof 's bucketing implementation. This allows us to perform resizing in the appropriate method.