### PR TITLE
try-catch load()

### DIFF
--- a/trainer/diffusers_trainer.py
+++ b/trainer/diffusers_trainer.py
@@ -162,8 +162,14 @@ class ImageStore:
 
     def __valid_file(self, f) -> bool:
         try:
-            Image.open(f)
+            Image.open(f).load()
             return True
+        except OSError as error:
+            if 'truncated' in str(error):
+                print(f'WARNING: Truncated image: {f}')
+                return False
+            print(f'WARNING: Unable to open file: {f}')
+            return False
         except:
             print(f'WARNING: Unable to open file: {f}')
             return False


### PR DESCRIPTION
### Fixes
- Check for truncated images for `convert()` operations, as it stands the error that is uncaught when this runs does not inform the user which file produced the error, this does that as well as skips the file in question.