### PR TITLE
Implementation of validation/resize classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+aesthetic/**
+*_cropped/
+*_cropped/**
+**/nsfw-ids.txt
+**/*.image
+**/*.caption
+**/dataset*.tar
+*/**/*.json
+**/*.png
+**/*.jpg

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,9 @@
 aesthetic/**
-*_cropped/
-*_cropped/**
+**/*_cropped
 **/nsfw-ids.txt
 **/*.image
 **/*.caption
 **/dataset*.tar
-*/**/*.json
+**/*.json
 **/*.png
 **/*.jpg

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-aesthetic/**
-**/*_cropped
+*_cropped/
 **/nsfw-ids.txt
 **/*.image
 **/*.caption

--- a/trainer/diffusers_trainer.py
+++ b/trainer/diffusers_trainer.py
@@ -86,9 +86,9 @@ parser.add_argument('--clip_penultimate', type=bool_t, default='False', help='Us
 parser.add_argument('--output_bucket_info', type=bool_t, default='False', help='Outputs bucket information and exits')
 parser.add_argument('--resize', type=bool_t, default='False', help="Resizes dataset's images to the appropriate bucket dimensions.")
 parser.add_argument('--use_xformers', type=bool_t, default='False', help='Use memory efficient attention')
-parser.add_argument('--extended_validation', action='store_true', help='Perform extended validation of images to catch truncated or corrupt images.')
-parser.add_argument('--no_migration', action='store_true', help='Do not perform migration of dataset while the `--resize` flag is active. Migration creates an adjacent folder to the dataset with <dataset_dirname>_cropped.')
-parser.add_argument('--skip_validation', action='store_true', help='Skip validation of images, useful for speeding up loading of very large datasets that have already been validated.')
+parser.add_argument('--extended_validation', type=bool_t, default='False', help='Perform extended validation of images to catch truncated or corrupt images.')
+parser.add_argument('--no_migration', type=bool_t, default='False', help='Do not perform migration of dataset while the `--resize` flag is active. Migration creates an adjacent folder to the dataset with <dataset_dirname>_cropped.')
+parser.add_argument('--skip_validation', type=bool_t, default='False', help='Skip validation of images, useful for speeding up loading of very large datasets that have already been validated.')
 
 args = parser.parse_args()
 

--- a/trainer/diffusers_trainer.py
+++ b/trainer/diffusers_trainer.py
@@ -169,10 +169,6 @@ class Validation():
         self.validate = self.__validate
         print("Validation: Standard")
 
-    def completed(self) -> None:
-        self.validate = self.__no_op
-        return print('Validation complete. Skipping further validation.')
-
     def __validate(self, fp: str) -> bool:
         try:
             Image.open(fp)
@@ -724,14 +720,11 @@ def main():
         num_workers=0,
         collate_fn=dataset.collate_fn
     )
-
-    # Validate dataset and perform possible migration
-    for _, batch in enumerate(train_dataloader):
-        continue
-
-    store.validator.completed()
-
+    
+    # Migrate dataset
     if args.resize and args.data_migration:
+        for _, batch in enumerate(train_dataloader):
+            continue
         print(f"Completed resize and migration to '{args.dataset}_cropped' please relaunch the trainer without the --resize argument and train on the migrated dataset.")
         exit(0)
 

--- a/trainer/diffusers_trainer.py
+++ b/trainer/diffusers_trainer.py
@@ -159,8 +159,7 @@ class Validation():
     def __init__(self, is_skipped: bool, is_extended: bool) -> None:
         if is_skipped:
             self.validate = self.__no_op
-            print("Validation: Skipped")
-            return 
+            return print("Validation: Skipped")
 
         if is_extended:
             self.validate = self.__extended_validate

--- a/trainer/diffusers_trainer.py
+++ b/trainer/diffusers_trainer.py
@@ -266,17 +266,14 @@ class ImageStore:
         self.validator = Validation(
             args.skip_validation,
             args.extended_validation
-        )
+        ).validate
 
-        self.resizer = Resize(args.resize, args.data_migration)
+        self.resizer = Resize(args.resize, args.data_migration).resize
 
-        self.image_files = [x for x in self.image_files if self.__valid_file(x)]
+        self.image_files = [x for x in self.image_files if self.validator(x)]
 
     def __len__(self) -> int:
         return len(self.image_files)
-
-    def __valid_file(self, f) -> bool:
-        return self.validator.validate(f)
 
     # iterator returns images as PIL images and their index in the store
     def entries_iterator(self) -> Generator[Tuple[Img, int], None, None]:
@@ -285,7 +282,7 @@ class ImageStore:
 
     # get image by index
     def get_image(self, ref: Tuple[int, int, int]) -> Img:
-        return self.resizer.resize(
+        return self.resizer(
             self.image_files[ref[0]],
             ref[1],
             ref[2]

--- a/trainer/diffusers_trainer.py
+++ b/trainer/diffusers_trainer.py
@@ -26,6 +26,7 @@ import numpy as np
 import json
 import re
 import traceback
+import shutil
 
 try:
     pynvml.nvmlInit()
@@ -38,6 +39,7 @@ from diffusers.pipelines.stable_diffusion import StableDiffusionSafetyChecker
 from diffusers.optimization import get_scheduler
 from transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer
 from PIL import Image, ImageOps
+from PIL.Image import Image as Img
 
 from typing import Dict, List, Generator, Tuple
 from scipy.interpolate import interp1d
@@ -83,6 +85,10 @@ parser.add_argument('--clip_penultimate', type=str, default='False', help='Use p
 parser.add_argument('--output_bucket_info', type=str, default='False', help='Outputs bucket information and exits')
 parser.add_argument('--resize', type=str, default='False', help="Resizes dataset's images to the appropriate bucket dimensions.")
 parser.add_argument('--use_xformers', type=str, default='False', help='Use memory efficient attention')
+parser.add_argument('--extended_validation', type=str, default='False', help='Perform extended validation of images to catch truncated or corrupt images.')
+parser.add_argument('--data_migration', type=str, default='True', help='Perform migration of resized images into a directory relative to the dataset path. Saves into `<dataset_directory_name>_cropped`.')
+parser.add_argument('--skip_validation', type=str, default='False', help='Skip validation of images, useful for speeding up loading of very large datasets that have already been validated.')
+
 args = parser.parse_args()
 
 for arg in vars(args):
@@ -149,39 +155,153 @@ def _sort_by_ratio(bucket: tuple) -> float:
 def _sort_by_area(bucket: tuple) -> float:
     return bucket[0] * bucket[1]
 
+class Validation():
+    def __init__(self, is_skipped: bool, is_extended: bool) -> None:
+        if is_skipped:
+            self.validate = self.__no_op
+            print("Validation: Skipped")
+            return 
+
+        if is_extended:
+            self.validate = self.__extended_validate
+            return print("Validation: Extended")
+
+        self.validate = self.__validate
+        print("Validation: Standard")
+
+    def completed(self) -> None:
+        self.validate = self.__no_op
+        return print('Validation complete. Skipping further validation.')
+
+    def __validate(self, fp: str) -> bool:
+        try:
+            Image.open(fp)
+            return True
+        except:
+            print(f'WARNING: Image cannot be opened: {fp}')
+            return False
+
+    def __extended_validate(self, fp: str) -> bool:
+        try:
+            Image.open(fp).load()
+            return True
+        except (OSError) as error:
+            if 'truncated' in str(error):
+                print(f'WARNING: Image truncated: {error}')
+                return False
+            print(f'WARNING: Image cannot be opened: {error}')
+            return False
+        except:
+            print(f'WARNING: Image cannot be opened: {error}')
+            return False
+
+    def __no_op(self, fp: str) -> bool:
+        return True
+
+class Resize():
+    def __init__(self, is_resizing: bool, is_migrating: bool) -> None:
+        if not is_resizing:
+            self.resize = self.__no_op
+            return
+
+        if is_migrating:
+            self.resize = self.__migration
+            dataset_path = os.path.split(args.dataset)
+            self.__directory = os.path.join(
+                dataset_path[0],
+                f'{dataset_path[1]}_cropped'
+            )
+            os.makedirs(self.__directory, exist_ok=True)
+            return print(f"Resizing: Performing migration to '{self.__directory}'.")
+
+        self.resize = self.__no_migration
+
+    def __no_migration(self, image_path: str, w: int, h: int) -> Img:
+        return ImageOps.fit(
+                Image.open(image_path),
+                (w, h),
+                bleed=0.0,
+                centering=(0.5, 0.5),
+                method=Image.Resampling.LANCZOS
+            ).convert(mode='RGB')
+
+    def __migration(self, image_path: str, w: int, h: int) -> Img:
+        filename = re.sub('\.[^/.]+$', '', os.path.split(image_path)[1])
+
+        image = ImageOps.fit(
+                Image.open(image_path),
+                (w, h),
+                bleed=0.0,
+                centering=(0.5, 0.5),
+                method=Image.Resampling.LANCZOS
+            ).convert(mode='RGB')
+
+        image.save(
+            os.path.join(f'{self.__directory}', f'{filename}.jpg'),
+            optimize=True
+        )
+
+        try:
+            shutil.copy(
+                os.path.join(args.dataset, f'{filename}.txt'),
+                os.path.join(self.__directory, f'{filename}.txt'),
+                follow_symlinks=False
+            )
+        except (FileNotFoundError):
+            f = open(
+                os.path.join(self.__directory, f'{filename}.txt'),
+                'w',
+                encoding='UTF-8'
+            )
+            f.close()
+
+        return image
+
+    def __no_op(self, image_path: str, w: int, h: int) -> Img:
+        return Image.open(image_path)
+
 class ImageStore:
     def __init__(self, data_dir: str) -> None:
         self.data_dir = data_dir
 
         self.image_files = []
         [self.image_files.extend(glob.glob(f'{data_dir}' + '/*.' + e)) for e in ['jpg', 'jpeg', 'png', 'bmp', 'webp']]
+
+        self.validator = Validation(
+            args.skip_validation,
+            args.extended_validation
+        )
+
+        self.resizer = Resize(args.resize, args.data_migration)
+
         self.image_files = [x for x in self.image_files if self.__valid_file(x)]
 
     def __len__(self) -> int:
         return len(self.image_files)
 
     def __valid_file(self, f) -> bool:
-        try:
-            Image.open(f)
-            return True
-        except:
-            print(f'WARNING: Unable to open file: {f}')
-            return False
+        return self.validator.validate(f)
+
+
 
     # iterator returns images as PIL images and their index in the store
-    def entries_iterator(self) -> Generator[Tuple[Image.Image, int], None, None]:
+    def entries_iterator(self) -> Generator[Tuple[Img, int], None, None]:
         for f in range(len(self)):
-            yield Image.open(self.image_files[f]).convert(mode='RGB'), f
+            yield Image.open(self.image_files[f]), f
 
     # get image by index
-    def get_image(self, ref: Tuple[int, int, int]) -> Image.Image:
-        return Image.open(self.image_files[ref[0]]).convert(mode='RGB')
+    def get_image(self, ref: Tuple[int, int, int]) -> Img:
+        return self.resizer.resize(
+            self.image_files[ref[0]],
+            ref[1],
+            ref[2]
+        )
 
     # gets caption by removing the extension from the filename and replacing it with .txt
     def get_caption(self, ref: Tuple[int, int, int]) -> str:
-        filename = re.sub('\.[^/.]+$', '', self.image_files[ref[0]]) + '.txt'
-        with open(filename, 'r', encoding='UTF-8') as f:
-            return f.read()
+        #filename = re.sub('\.[^/.]+$', '', self.image_files[ref[0]]) + '.txt'
+        #with open(filename, 'r', encoding='UTF-8') as f:
+            return ''
 
 
 # ====================================== #
@@ -403,15 +523,6 @@ class AspectDataset(torch.utils.data.Dataset):
 
         image_file = self.store.get_image(item)
 
-        if args.resize:
-            image_file = ImageOps.fit(
-                image_file,
-                (item[1], item[2]),
-                bleed=0.0,
-                centering=(0.5, 0.5),
-                method=Image.Resampling.LANCZOS
-            )
-
         return_dict['pixel_values'] = self.transforms(image_file)
         if random.random() > self.ucg:
             caption_file = self.store.get_caption(item)
@@ -615,6 +726,16 @@ def main():
         num_workers=0,
         collate_fn=dataset.collate_fn
     )
+
+    # Validate dataset and perform possible migration
+    for _, batch in enumerate(train_dataloader):
+        continue
+
+    store.validator.completed()
+
+    if args.resize and args.migration:
+        print(f"Completed resize and migration to '{args.dataset}_cropped' please relaunch the trainer without the --resize argument and train on the migrated dataset.")
+        exit(0)
 
     weight_dtype = torch.float16 if args.fp16 else torch.float32
 

--- a/trainer/diffusers_trainer.py
+++ b/trainer/diffusers_trainer.py
@@ -733,7 +733,7 @@ def main():
 
     store.validator.completed()
 
-    if args.resize and args.migration:
+    if args.resize and args.data_migration:
         print(f"Completed resize and migration to '{args.dataset}_cropped' please relaunch the trainer without the --resize argument and train on the migrated dataset.")
         exit(0)
 

--- a/trainer/diffusers_trainer.py
+++ b/trainer/diffusers_trainer.py
@@ -299,9 +299,9 @@ class ImageStore:
 
     # gets caption by removing the extension from the filename and replacing it with .txt
     def get_caption(self, ref: Tuple[int, int, int]) -> str:
-        #filename = re.sub('\.[^/.]+$', '', self.image_files[ref[0]]) + '.txt'
-        #with open(filename, 'r', encoding='UTF-8') as f:
-            return ''
+        filename = re.sub('\.[^/.]+$', '', self.image_files[ref[0]]) + '.txt'
+        with open(filename, 'r', encoding='UTF-8') as f:
+            return f.read()
 
 
 # ====================================== #

--- a/trainer/diffusers_trainer.py
+++ b/trainer/diffusers_trainer.py
@@ -57,10 +57,10 @@ parser.add_argument('--bucket_side_max', type=int, default=768, help='The maximu
 parser.add_argument('--lr', type=float, default=5e-6, help='Learning rate')
 parser.add_argument('--epochs', type=int, default=10, help='Number of epochs to train for')
 parser.add_argument('--batch_size', type=int, default=1, help='Batch size')
-parser.add_argument('--use_ema', type=bool, default=False, help='Use EMA for finetuning')
+parser.add_argument('--use_ema', type=str, default='False', help='Use EMA for finetuning')
 parser.add_argument('--ucg', type=float, default=0.1, help='Percentage chance of dropping out the text condition per batch. Ranges from 0.0 to 1.0 where 1.0 means 100% text condition dropout.') # 10% dropout probability
-parser.add_argument('--gradient_checkpointing', dest='gradient_checkpointing', type=bool, default=False, help='Enable gradient checkpointing')
-parser.add_argument('--use_8bit_adam', dest='use_8bit_adam', type=bool, default=False, help='Use 8-bit Adam optimizer')
+parser.add_argument('--gradient_checkpointing', dest='gradient_checkpointing', type=str, default='False', help='Enable gradient checkpointing')
+parser.add_argument('--use_8bit_adam', dest='use_8bit_adam', type=str, default='False', help='Use 8-bit Adam optimizer')
 parser.add_argument('--adam_beta1', type=float, default=0.9, help='Adam beta1')
 parser.add_argument('--adam_beta2', type=float, default=0.999, help='Adam beta2')
 parser.add_argument('--adam_weight_decay', type=float, default=1e-2, help='Adam weight decay')
@@ -71,19 +71,26 @@ parser.add_argument('--seed', type=int, default=42, help='Seed for random number
 parser.add_argument('--output_path', type=str, default='./output', help='Root path for all outputs.')
 parser.add_argument('--save_steps', type=int, default=500, help='Number of steps to save checkpoints at.')
 parser.add_argument('--resolution', type=int, default=512, help='Image resolution to train against. Lower res images will be scaled up to this resolution and higher res images will be scaled down.')
-parser.add_argument('--shuffle', dest='shuffle', type=bool, default=True, help='Shuffle dataset')
+parser.add_argument('--shuffle', dest='shuffle', type=str, default='True', help='Shuffle dataset')
 parser.add_argument('--hf_token', type=str, default=None, required=False, help='A HuggingFace token is needed to download private models for training.')
 parser.add_argument('--project_id', type=str, default='diffusers', help='Project ID for reporting to WandB')
-parser.add_argument('--fp16', dest='fp16', type=bool, default=False, help='Train in mixed precision')
+parser.add_argument('--fp16', dest='fp16', type=str, default='False', help='Train in mixed precision')
 parser.add_argument('--image_log_steps', type=int, default=100, help='Number of steps to log images at.')
 parser.add_argument('--image_log_amount', type=int, default=4, help='Number of images to log every image_log_steps')
 parser.add_argument('--image_log_inference_steps', type=int, default=50, help='Number of inference steps to use to log images.')
 parser.add_argument('--image_log_scheduler', type=str, default="PNDMScheduler", help='Number of inference steps to use to log images.')
-parser.add_argument('--clip_penultimate', type=bool, default=False, help='Use penultimate CLIP layer for text embedding')
-parser.add_argument('--output_bucket_info', type=bool, default=False, help='Outputs bucket information and exits')
-parser.add_argument('--resize', type=bool, default=False, help="Resizes dataset's images to the appropriate bucket dimensions.")
-parser.add_argument('--use_xformers', type=bool, default=False, help='Use memory efficient attention')
+parser.add_argument('--clip_penultimate', type=str, default='False', help='Use penultimate CLIP layer for text embedding')
+parser.add_argument('--output_bucket_info', type=str, default='False', help='Outputs bucket information and exits')
+parser.add_argument('--resize', type=str, default='False', help="Resizes dataset's images to the appropriate bucket dimensions.")
+parser.add_argument('--use_xformers', type=str, default='False', help='Use memory efficient attention')
 args = parser.parse_args()
+
+for arg in vars(args):
+    if type(getattr(args, arg)) == str:
+        if getattr(args, arg).lower() == 'true':
+            setattr(args, arg, True)
+        elif getattr(args, arg).lower() == 'false':
+            setattr(args, arg, False)
 
 def setup():
     torch.distributed.init_process_group("nccl", init_method="env://")

--- a/trainer/diffusers_trainer.py
+++ b/trainer/diffusers_trainer.py
@@ -282,8 +282,6 @@ class ImageStore:
     def __valid_file(self, f) -> bool:
         return self.validator.validate(f)
 
-
-
     # iterator returns images as PIL images and their index in the store
     def entries_iterator(self) -> Generator[Tuple[Img, int], None, None]:
         for f in range(len(self)):

--- a/trainer/diffusers_trainer.py
+++ b/trainer/diffusers_trainer.py
@@ -2,8 +2,8 @@
 # `nvcc --version` to get CUDA version.
 # `pip install -i https://test.pypi.org/simple/ bitsandbytes-cudaXXX` to install for current CUDA.
 # Example Usage:
-# Single GPU: torchrun --nproc_per_node=1 trainer_dist.py --model="CompVis/stable-diffusion-v1-4" --run_name="liminal" --dataset="liminal-dataset" --hf_token="hf_blablabla" --bucket_side_min=64 --use_8bit_adam=True --gradient_checkpointing=True --batch_size=10 --fp16=True --image_log_steps=250 --epochs=20 --resolution=768 --use_ema=True
-# Multiple GPUs: torchrun --nproc_per_node=N trainer_dist.py --model="CompVis/stable-diffusion-v1-4" --run_name="liminal" --dataset="liminal-dataset" --hf_token="hf_blablabla" --bucket_side_min=64 --use_8bit_adam=True --gradient_checkpointing=True --batch_size=10 --fp16=True --image_log_steps=250 --epochs=20 --resolution=768 --use_ema=True
+# Single GPU: torchrun --nproc_per_node=1 trainer/diffusers_trainer.py --model="CompVis/stable-diffusion-v1-4" --run_name="liminal" --dataset="liminal-dataset" --hf_token="hf_blablabla" --bucket_side_min=64 --use_8bit_adam --gradient_checkpointing --batch_size=1 --fp16 --image_log_steps=250 --epochs=20 --resolution=768 --use_ema
+# Multiple GPUs: torchrun --nproc_per_node=N trainer/diffusers_trainer.py --model="CompVis/stable-diffusion-v1-4" --run_name="liminal" --dataset="liminal-dataset" --hf_token="hf_blablabla" --bucket_side_min=64 --use_8bit_adam --gradient_checkpointing --batch_size=10 --fp16 --image_log_steps=250 --epochs=20 --resolution=768 --use_ema
 
 import argparse
 import socket

--- a/trainer/diffusers_trainer.py
+++ b/trainer/diffusers_trainer.py
@@ -89,7 +89,7 @@ parser.add_argument('--output_bucket_info', action='store_true', help='Outputs b
 parser.add_argument('--resize', action='store_true', help="Resizes dataset's images to the appropriate bucket dimensions.")
 parser.add_argument('--use_xformers', action='store_true', help='Use memory efficient attention')
 parser.add_argument('--extended_validation', action='store_true', help='Perform extended validation of images to catch truncated or corrupt images.')
-parser.add_argument('--no_migration', action='store_true', help='Perform migration of resized images into a directory relative to the dataset path. Saves into `<dataset_directory_name>_cropped`.')
+parser.add_argument('--no_migration', action='store_true', help='Do not perform migration of dataset while the `--resize` flag is active. Migration creates an adjacent folder to the dataset with <dataset_dirname>_cropped.')
 parser.add_argument('--skip_validation', action='store_true', help='Skip validation of images, useful for speeding up loading of very large datasets that have already been validated.')
 
 args = parser.parse_args()

--- a/trainer/diffusers_trainer.py
+++ b/trainer/diffusers_trainer.py
@@ -86,6 +86,10 @@ parser.add_argument('--clip_penultimate', type=bool_t, default='False', help='Us
 parser.add_argument('--output_bucket_info', type=bool_t, default='False', help='Outputs bucket information and exits')
 parser.add_argument('--resize', type=bool_t, default='False', help="Resizes dataset's images to the appropriate bucket dimensions.")
 parser.add_argument('--use_xformers', type=bool_t, default='False', help='Use memory efficient attention')
+parser.add_argument('--extended_validation', action='store_true', help='Perform extended validation of images to catch truncated or corrupt images.')
+parser.add_argument('--no_migration', action='store_true', help='Do not perform migration of dataset while the `--resize` flag is active. Migration creates an adjacent folder to the dataset with <dataset_dirname>_cropped.')
+parser.add_argument('--skip_validation', action='store_true', help='Skip validation of images, useful for speeding up loading of very large datasets that have already been validated.')
+
 args = parser.parse_args()
 
 def setup():


### PR DESCRIPTION
### Features
- When `--resize` is `True`, `--data_migration` (`default: True`), data migration would create a clone of the relative path to the dataset path, and output `%DATASET%_cropped` adjacent to the dataset directory. This is to make sure this expensive operation is only run once.
- Currently the `.load()` operation substantially extends validation time (from ~1000f/s to ~100f/s), while being more extensive it feels like for already-prepared datasets the slowdown is not worth it, despite the lack of verbose debugging upon hitting truncated/corrupted files. Subsequently the addition of `--extended_validation` (`default: False`) would allow users to easily perform one-time extended validation.
- The conversion to 3-channel RGB would be moved into the `--resize` default migration, further speeding up operations on already-validated datasets.
- Addition of `skip_validation` argument for already-validated datasets to speed up the loading procedure.