### PR TITLE
fix wandb init mode, don't log hf token

### DIFF
--- a/trainer/diffusers_trainer.py
+++ b/trainer/diffusers_trainer.py
@@ -624,10 +624,12 @@ def main():
     if rank == 0:
         os.makedirs(args.output_path, exist_ok=True)
         
-        mode = 'enabled'
+        mode = 'disabled'
         if args.enablewandb:
-            mode = 'disabled'
-        
+            mode = 'online'
+        if args.hf_token is not None:
+            os.environ['HF_API_TOKEN'] = args.hf_token
+            args.hf_token = None
         run = wandb.init(project=args.project_id, name=args.run_name, config=vars(args), dir=args.output_path+'/wandb', mode=mode)
 
         # Inform the user of host, and various versions -- useful for debugging issues.


### PR DESCRIPTION
Fix using --wandb sets it to 'disabled' instead of enabling it.
Use correct value for mode ('enabled' is invalid, either 'online', 'offline' or 'disabled')
Clear hf_token passed to wandb to avoid leaking it via the wandb log.